### PR TITLE
add multibyte support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,5 +10,8 @@
     "require-dev": {
         "phpunit/phpunit": "4.4.0"
     },
-    "license": "MIT"
+    "license": "MIT",
+    "require": {
+        "symfony/polyfill-mbstring": "^1.4"
+    }
 }

--- a/src/AbstractCaseHelper.php
+++ b/src/AbstractCaseHelper.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace CaseHelper;
+
+abstract class AbstractCaseHelper implements CaseHelperInterface
+{
+    const INT_MAX = 2147483647;
+
+    protected $encoding;
+
+    public function __construct($encoding)
+    {
+        $this->encoding = $encoding;
+    }
+
+    protected function mb_ucfirst($string, $encoding)
+    {
+        $strlen    = mb_strlen($string, $encoding);
+        $firstChar = mb_substr($string, 0, 1, $encoding);
+        $then      = mb_substr($string, 1, $strlen - 1, $encoding);
+        return mb_strtoupper($firstChar, $encoding).$then;
+    }
+
+    protected function mb_lcfirst($string, $encoding)
+    {
+        $strlen    = mb_strlen($string, $encoding);
+        $firstChar = mb_substr($string, 0, 1, $encoding);
+        $then      = mb_substr($string, 1, $strlen - 1, $encoding);
+        return mb_strtolower($firstChar, $encoding).$then;
+    }
+}

--- a/src/CamelCaseHelper.php
+++ b/src/CamelCaseHelper.php
@@ -6,12 +6,12 @@ namespace CaseHelper;
 /**
  * Converts camelCase strings to other formats.
  */
-class CamelCaseHelper implements CaseHelperInterface {
+class CamelCaseHelper extends AbstractCaseHelper {
 
-    private $separatorPattern = '/((?<=[^$])[A-Z0-9])/';
+    private $separatorPattern = '/((?<=[^$])[A-Z0-9])/u';
 
     public function toSpaceCase($str) {
-        return strtolower(preg_replace($this->separatorPattern, ' $1', $str));
+        return mb_strtolower(preg_replace($this->separatorPattern, ' $1', $str), $this->encoding);
     }
 
     public function toCamelCase($str) {
@@ -19,22 +19,22 @@ class CamelCaseHelper implements CaseHelperInterface {
     }
 
     public function toPascalCase($str) {
-        return ucfirst($str);
+        return $this->mb_ucfirst($str, $this->encoding);
     }
 
     public function toKebabCase($str) {
-        return strtolower($this->toTrainCase($str));
+        return mb_strtolower($this->toTrainCase($str), $this->encoding);
     }
 
     public function toTrainCase($str) {
-        return ucfirst(preg_replace($this->separatorPattern, '-$1', $str));
+        return $this->mb_ucfirst(preg_replace($this->separatorPattern, '-$1', $str), $this->encoding);
     }
 
     public function toSnakeCase($str) {
-        return strtolower(preg_replace($this->separatorPattern, '_$1', $str));
+        return mb_strtolower(preg_replace($this->separatorPattern, '_$1', $str), $this->encoding);
     }
 
     public function toScreamingSnakeCase($str) {
-        return strtoupper($this->toSnakeCase($str));
+        return mb_strtoupper($this->toSnakeCase($str), $this->encoding);
     }
 }

--- a/src/CaseHelperFactory.php
+++ b/src/CaseHelperFactory.php
@@ -19,30 +19,30 @@ class CaseHelperFactory {
     const INPUT_TYPE_SNAKE_CASE = 6;
     const INPUT_TYPE_SCREAMING_SNAKE_CASE = 7;
 
-    public static function make($inputType) {
+    public static function make($inputType, $encoding = 'UTF-8') {
         $o = null;
 
         switch ($inputType) {
             case static::INPUT_TYPE_SPACE_CASE:
-                $o = new SpaceCaseHelper();
+                $o = new SpaceCaseHelper($encoding);
                 break;
             case static::INPUT_TYPE_CAMEL_CASE:
-                $o = new CamelCaseHelper();
+                $o = new CamelCaseHelper($encoding);
                 break;
             case static::INPUT_TYPE_PASCAL_CASE:
-                $o = new PascalCaseHelper();
+                $o = new PascalCaseHelper($encoding);
                 break;
             case static::INPUT_TYPE_KEBAB_CASE:
-                $o = new KebabCaseHelper();
+                $o = new KebabCaseHelper($encoding);
                 break;
             case static::INPUT_TYPE_TRAIN_CASE:
-                $o = new TrainCaseHelper();
+                $o = new TrainCaseHelper($encoding);
                 break;
             case static::INPUT_TYPE_SNAKE_CASE;
-                $o = new SnakeCaseHelper();
+                $o = new SnakeCaseHelper($encoding);
                 break;
             case static::INPUT_TYPE_SCREAMING_SNAKE_CASE:
-                $o = new ScreamingSnakeCaseHelper();
+                $o = new ScreamingSnakeCaseHelper($encoding);
                 break;
             default:
                 throw new Exception('Unknown input case type: ' . $inputType);

--- a/src/CaseHelperInterface.php
+++ b/src/CaseHelperInterface.php
@@ -9,6 +9,13 @@ namespace CaseHelper;
 interface CaseHelperInterface {
 
     /**
+     * This library supports multibyte, thus encoding should be provided.
+     *
+     * @param string $encoding
+     */
+    public function __construct($encoding);
+
+    /**
      * Converts the specified string to space case.
      *
      * @param string $str

--- a/src/KebabCaseHelper.php
+++ b/src/KebabCaseHelper.php
@@ -6,9 +6,9 @@ namespace CaseHelper;
 /**
  * Converts kabab-case strings to other formats.
  */
-class KebabCaseHelper implements CaseHelperInterface {
+class KebabCaseHelper extends AbstractCaseHelper {
 
-    private $separatorPattern = '/-([A-Za-z0-9])/';
+    private $separatorPattern = '/-(.)/u';
 
     public function toSpaceCase($str) {
         return preg_replace_callback($this->separatorPattern, function($el) {
@@ -17,9 +17,9 @@ class KebabCaseHelper implements CaseHelperInterface {
     }
 
     public function toCamelCase($str) {
-        return preg_replace_callback($this->separatorPattern, function($el) {
-            return strtoupper($el[1]);
-        }, $str);
+        return $this->mb_lcfirst(preg_replace_callback($this->separatorPattern, function($el) {
+            return mb_strtoupper($el[1], $this->encoding);
+        }, $str), $this->encoding);
     }
 
     public function toKebabCase($str) {
@@ -27,11 +27,11 @@ class KebabCaseHelper implements CaseHelperInterface {
     }
 
     public function toPascalCase($str) {
-        return ucfirst($this->toCamelCase($str));
+        return $this->mb_ucfirst($this->toCamelCase($str), $this->encoding);
     }
 
     public function toScreamingSnakeCase($str) {
-        return strtoupper($this->toSnakeCase($str));
+        return mb_strtoupper($this->toSnakeCase($str), $this->encoding);
     }
 
     public function toSnakeCase($str) {
@@ -41,8 +41,8 @@ class KebabCaseHelper implements CaseHelperInterface {
     }
 
     public function toTrainCase($str) {
-        return ucfirst(preg_replace_callback('/-([A-Za-z])/', function($el) {
-            return strtoupper($el[0]);
-        }, $str));
+        return $this->mb_ucfirst(preg_replace_callback('/-([A-Za-z])/u', function($el) {
+            return mb_strtoupper($el[0], $this->encoding);
+        }, $str), $this->encoding);
     }
 }

--- a/src/PascalCaseHelper.php
+++ b/src/PascalCaseHelper.php
@@ -6,20 +6,20 @@ namespace CaseHelper;
 /**
  * Converts PascalCase strings to other formats.
  */
-class PascalCaseHelper implements CaseHelperInterface {
+class PascalCaseHelper extends AbstractCaseHelper {
 
-    private $separatorPattern = '/((?<=[^$])[A-Z0-9])/';
+    private $separatorPattern = '/((?<=[^$])[A-Z0-9])/u';
 
     public function toSpaceCase($str) {
-        return strtolower(preg_replace($this->separatorPattern, ' $1', $str));
+        return mb_strtolower(preg_replace($this->separatorPattern, ' $1', $str), $this->encoding);
     }
 
     public function toCamelCase($str) {
-        return lcfirst($str);
+        return $this->mb_lcfirst($str, $this->encoding);
     }
 
     public function toKebabCase($str) {
-        return strtolower($this->toTrainCase($str));
+        return mb_strtolower($this->toTrainCase($str), $this->encoding);
     }
 
     public function toPascalCase($str) {
@@ -27,7 +27,7 @@ class PascalCaseHelper implements CaseHelperInterface {
     }
 
     public function toScreamingSnakeCase($str) {
-        return strtoupper($this->toSnakeCase($str));
+        return mb_strtoupper($this->toSnakeCase($str), $this->encoding);
     }
 
     public function toSnakeCase($str) {

--- a/src/ScreamingSnakeCaseHelper.php
+++ b/src/ScreamingSnakeCaseHelper.php
@@ -6,26 +6,26 @@ namespace CaseHelper;
 /**
  * Converts SCREAMING_SNAKE_CASE strings to other formats.
  */
-class ScreamingSnakeCaseHelper implements CaseHelperInterface {
+class ScreamingSnakeCaseHelper extends AbstractCaseHelper {
 
     public function toSpaceCase($str) {
-        return strtolower(str_replace('_', ' ', $str));
+        return mb_strtolower(str_replace('_', ' ', $str), $this->encoding);
     }
 
     public function toCamelCase($str) {
-        return preg_replace_callback('/_[a-z0-9]/', function($el) {
-            return strtoupper(substr($el[0], 1));
-        }, strtolower($str));
+        return preg_replace_callback('/_./u', function($el) {
+            return mb_strtoupper(mb_substr($el[0], 1, parent::INT_MAX, $this->encoding), $this->encoding);
+        }, mb_strtolower($str, $this->encoding));
     }
 
     public function toKebabCase($str) {
-        return strtolower(preg_replace_callback('/_[A-Z0-9]/', function($el) {
-            return '-' . substr($el[0], 1);
-        }, $str));
+        return mb_strtolower(preg_replace_callback('/_./u', function($el) {
+            return '-' . mb_substr($el[0], 1, parent::INT_MAX, $this->encoding);
+        }, $str), $this->encoding);
     }
 
     public function toPascalCase($str) {
-        return ucfirst($this->toCamelCase($str));
+        return $this->mb_ucfirst($this->toCamelCase($str), $this->encoding);
     }
 
     public function toScreamingSnakeCase($str) {
@@ -33,13 +33,12 @@ class ScreamingSnakeCaseHelper implements CaseHelperInterface {
     }
 
     public function toSnakeCase($str) {
-        return strtolower($str);
+        return mb_strtolower($str, $this->encoding);
     }
 
     public function toTrainCase($str) {
-
-        return ucfirst(preg_replace_callback('/_[a-z0-9]/', function($el) {
-            return '-' . strtoupper(substr($el[0], 1));
-        }, strtolower($str)));
+        return $this->mb_ucfirst(preg_replace_callback('/_./u', function($el) {
+            return '-' . mb_strtoupper(mb_substr($el[0], 1, parent::INT_MAX, $this->encoding), $this->encoding);
+        }, mb_strtolower($str, $this->encoding)), $this->encoding);
     }
 }

--- a/src/SnakeCaseHelper.php
+++ b/src/SnakeCaseHelper.php
@@ -6,30 +6,30 @@ namespace CaseHelper;
 /**
  * Converts snake_case strings to other formats.
  */
-class SnakeCaseHelper implements CaseHelperInterface {
+class SnakeCaseHelper extends AbstractCaseHelper {
 
     public function toSpaceCase($str) {
         return str_replace('_', ' ', $str);
     }
 
     public function toCamelCase($str) {
-        return preg_replace_callback('/_[a-z0-9]/', function($el) {
-            return strtoupper(substr($el[0], 1));
-        }, $str);
+        return $this->mb_lcfirst(preg_replace_callback('/_./u', function($el) {
+            return mb_strtoupper(mb_substr($el[0], 1, parent::INT_MAX, $this->encoding), $this->encoding);
+        }, $str), $this->encoding);
     }
 
     public function toKebabCase($str) {
-        return preg_replace_callback('/_[a-z0-9]/', function($el) {
-            return '-' . substr($el[0], 1);
+        return preg_replace_callback('/_./u', function($el) {
+            return '-' . mb_substr($el[0], 1, parent::INT_MAX, $this->encoding);
         }, $str);
     }
 
     public function toPascalCase($str) {
-        return ucfirst($this->toCamelCase($str));
+        return $this->mb_ucfirst($this->toCamelCase($str), $this->encoding);
     }
 
     public function toScreamingSnakeCase($str) {
-        return strtoupper($str);
+        return mb_strtoupper($str, $this->encoding);
     }
 
     public function toSnakeCase($str) {
@@ -38,8 +38,8 @@ class SnakeCaseHelper implements CaseHelperInterface {
 
     public function toTrainCase($str) {
 
-        return ucfirst(preg_replace_callback('/_[a-z0-9]/', function($el) {
-            return '-' . strtoupper(substr($el[0], 1));
-        }, $str));
+        return $this->mb_ucfirst(preg_replace_callback('/_./u', function($el) {
+            return '-' . mb_strtoupper(mb_substr($el[0], 1, parent::INT_MAX, $this->encoding), $this->encoding);
+        }, $str), $this->encoding);
     }
 }

--- a/src/SpaceCaseHelper.php
+++ b/src/SpaceCaseHelper.php
@@ -6,46 +6,46 @@ namespace CaseHelper;
 /**
  * Converts space case strings to other formats.
  */
-class SpaceCaseHelper implements CaseHelperInterface {
+class SpaceCaseHelper extends AbstractCaseHelper {
 
-    private $separatorPattern = '/\s+([^\s])/';
+    private $separatorPattern = '/\s+([^\s])/u';
 
     public function toSpaceCase($str) {
         return $str;
     }
 
     public function toCamelCase($str) {
-        return preg_replace_callback($this->separatorPattern, function($el) {
-            return strtoupper($el[1]);
-        }, $this->cleanString($str));
+        return $this->mb_lcfirst(preg_replace_callback($this->separatorPattern, function($el) {
+            return mb_strtoupper($el[1], $this->encoding);
+        }, $this->cleanString($str)), $this->encoding);
     }
 
     public function toPascalCase($str) {
-        return ucfirst($this->toCamelCase($str));
+        return $this->mb_ucfirst($this->toCamelCase($str), $this->encoding);
     }
 
     public function toKebabCase($str) {
-        return strtolower(preg_replace_callback($this->separatorPattern, function($el) {
+        return mb_strtolower(preg_replace_callback($this->separatorPattern, function($el) {
             return '-' . ($el[1]);
-        }, $this->cleanString($str)));
+        }, $this->cleanString($str)), $this->encoding);
     }
 
     public function toTrainCase($str) {
-        return ucfirst(preg_replace_callback($this->separatorPattern, function($el) {
-            return '-' . strtoupper($el[1]);
-        }, $this->cleanString($str)));
+        return $this->mb_ucfirst(preg_replace_callback($this->separatorPattern, function($el) {
+            return '-' . mb_strtoupper($el[1], $this->encoding);
+        }, $this->cleanString($str)), $this->encoding);
     }
 
     public function toSnakeCase($str) {
-        return strtolower(preg_replace_callback($this->separatorPattern, function($el) {
+        return mb_strtolower(preg_replace_callback($this->separatorPattern, function($el) {
             return '_' . $el[1];
-        }, $this->cleanString($str)));
+        }, $this->cleanString($str)), $this->encoding);
     }
 
     public function toScreamingSnakeCase($str) {
-        return strtoupper(preg_replace_callback($this->separatorPattern, function($el) {
+        return mb_strtoupper(preg_replace_callback($this->separatorPattern, function($el) {
             return '_' . $el[1];
-        }, $this->cleanString($str)));
+        }, $this->cleanString($str)), $this->encoding);
     }
 
     /**
@@ -55,6 +55,6 @@ class SpaceCaseHelper implements CaseHelperInterface {
      * @return string
      */
     private function cleanString($str) {
-        return trim(preg_replace('/[^A-Za-z0-9\s]/', '', $str));
+        return trim(preg_replace('/[^A-Za-z0-9\s]/u', '', $str));
     }
 }

--- a/src/TrainCaseHelper.php
+++ b/src/TrainCaseHelper.php
@@ -6,34 +6,34 @@ namespace CaseHelper;
 /**
  * Converts Train-Case strings to other formats.
  */
-class TrainCaseHelper implements CaseHelperInterface {
+class TrainCaseHelper extends AbstractCaseHelper {
 
     public function toSpaceCase($str) {
-        return strtolower(str_replace('-', ' ', $str));
+        return mb_strtolower(str_replace('-', ' ', $str), $this->encoding);
     }
 
     public function toCamelCase($str) {
-        return lcfirst($this->toPascalCase($str));
+        return $this->mb_lcfirst($this->toPascalCase($str), $this->encoding);
     }
 
     public function toKebabCase($str) {
-        return strtolower($str);
+        return mb_strtolower($str, $this->encoding);
     }
 
     public function toPascalCase($str) {
-        return preg_replace_callback('/-[A-Z0-9]/', function($el) {
-            return strtoupper(substr($el[0], 1));
+        return preg_replace_callback('/-./u', function($el) {
+            return mb_strtoupper(mb_substr($el[0], 1, parent::INT_MAX, $this->encoding), $this->encoding);
         }, $str);
     }
 
     public function toScreamingSnakeCase($str) {
-        return strtoupper($this->toSnakeCase($str));
+        return mb_strtoupper($this->toSnakeCase($str), $this->encoding);
     }
 
     public function toSnakeCase($str) {
-        return strtolower(preg_replace_callback('/-[A-Z0-9]/', function($el) {
-            return '_' . substr($el[0], 1);
-        }, $str));
+        return mb_strtolower(preg_replace_callback('/-./', function($el) {
+            return '_' . mb_substr($el[0], 1, parent::INT_MAX, $this->encoding);
+        }, $str), $this->encoding);
     }
 
     public function toTrainCase($str) {

--- a/tests/Unit/CaseHelper/CamelCaseInputTest.php
+++ b/tests/Unit/CaseHelper/CamelCaseInputTest.php
@@ -20,7 +20,10 @@ class CamelCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toCamelCase', array(
             'myCamelCase' => 'myCamelCase',
             'otherStuffInCamelCase' => 'otherStuffInCamelCase',
-            'watEva' => 'watEva'
+            'watEva' => 'watEva',
+            'dontL👀kAtMeLikeThat' => 'dontL👀kAtMeLikeThat',
+            'my🍕IsGood' => 'my🍕IsGood',
+            "friday🍺sForever" => 'friday🍺sForever'
         ));
     }
 
@@ -29,7 +32,10 @@ class CamelCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toSpaceCase', array(
             'someCamelCasedStr' => 'some camel cased str',
             '1Is4Real2' => '1 is 4 real 2',
-            'alrightThen' => 'alright then'
+            'alrightThen' => 'alright then',
+            'dontL👀kAtMeLikeThat' => 'dont l👀k at me like that',
+            'my🍕IsGood' => 'my🍕 is good',
+            "friday🍺sForever" => 'friday🍺s forever'
         ));
     }
 
@@ -37,7 +43,10 @@ class CamelCaseInputTest extends TestCase {
 
         $this->assertCaseHelperConvertsCasesCorrectly('toPascalCase', array(
             'mySuperCoolTest' => 'MySuperCoolTest',
-            'iAmSoUnsureOfMyCase' => 'IAmSoUnsureOfMyCase'
+            'iAmSoUnsureOfMyCase' => 'IAmSoUnsureOfMyCase',
+            'dontL👀kAtMeLikeThat' => 'DontL👀kAtMeLikeThat',
+            'my🍕IsGood' => 'My🍕IsGood',
+            "friday🍺sForever" => 'Friday🍺sForever'
         ));
     }
 
@@ -46,7 +55,10 @@ class CamelCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toKebabCase', array(
             'ohItsCool' => 'oh-its-cool',
             'letMeTryAnotherOneOk?' => 'let-me-try-another-one-ok?',
-            'kebabMe' => 'kebab-me'
+            'kebabMe' => 'kebab-me',
+            'dontL👀kAtMeLikeThat' => 'dont-l👀k-at-me-like-that',
+            'my🍕IsGood' => 'my🍕-is-good',
+            "friday🍺sForever" => 'friday🍺s-forever'
         ));
     }
 
@@ -55,7 +67,10 @@ class CamelCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toTrainCase', array(
             'someCamelStuff' => 'Some-Camel-Stuff',
             'whatchaGonnaDo?' => 'Whatcha-Gonna-Do?',
-            'iHaveNoIdeaWhatImDoing12' => 'I-Have-No-Idea-What-Im-Doing-1-2'
+            'iHaveNoIdeaWhatImDoing12' => 'I-Have-No-Idea-What-Im-Doing-1-2',
+            'dontL👀kAtMeLikeThat' => 'Dont-L👀k-At-Me-Like-That',
+            'my🍕IsGood' => 'My🍕-Is-Good',
+            "friday🍺sForever" => 'Friday🍺s-Forever'
         ));
     }
 
@@ -65,7 +80,10 @@ class CamelCaseInputTest extends TestCase {
             'itsRainingBeCareful' => 'its_raining_be_careful',
             'iWillThinkAboutItOk?' => 'i_will_think_about_it_ok?',
             'snakeMe' => 'snake_me',
-            'withNumber9' => 'with_number_9'
+            'withNumber9' => 'with_number_9',
+            'dontL👀kAtMeLikeThat' => 'dont_l👀k_at_me_like_that',
+            'my🍕IsGood' => 'my🍕_is_good',
+            "friday🍺sForever" => 'friday🍺s_forever'
         ));
     }
 
@@ -73,7 +91,10 @@ class CamelCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toScreamingSnakeCase', array(
             'someCamelCaseAsUsual' => 'SOME_CAMEL_CASE_AS_USUAL',
             'ohHiCaptainCapslock' => 'OH_HI_CAPTAIN_CAPSLOCK',
-            '4You' => '4_YOU'
+            '4You' => '4_YOU',
+            'dontL👀kAtMeLikeThat' => 'DONT_L👀K_AT_ME_LIKE_THAT',
+            'my🍕IsGood' => 'MY🍕_IS_GOOD',
+            "friday🍺sForever" => 'FRIDAY🍺S_FOREVER'
         ));
     }
 }

--- a/tests/Unit/CaseHelper/KebabCaseInputTest.php
+++ b/tests/Unit/CaseHelper/KebabCaseInputTest.php
@@ -19,7 +19,10 @@ class KebabCaseInputTest extends TestCase {
 
         $this->assertCaseHelperConvertsCasesCorrectly('toKebabCase', array(
             'my-kebab-input' => 'my-kebab-input',
-            'oh-dont-mind' => 'oh-dont-mind'
+            'oh-dont-mind' => 'oh-dont-mind',
+            'dont-l👀k-at-me-like-that' => 'dont-l👀k-at-me-like-that',
+            'my-🍕-is-good' => 'my-🍕-is-good',
+            "friday-🍺s-forever" => 'friday-🍺s-forever'
         ));
     }
 
@@ -28,7 +31,10 @@ class KebabCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toSpaceCase', array(
             'i-am-kebab' => 'i am kebab',
             '3-2-1-go' => '3 2 1 go',
-            '4-you-2' => '4 you 2'
+            '4-you-2' => '4 you 2',
+            'dont-l👀k-at-me-like-that' => 'dont l👀k at me like that',
+            'my-🍕-is-good' => 'my 🍕 is good',
+            "friday-🍺s-forever" => 'friday 🍺s forever'
         ));
     }
 
@@ -37,7 +43,10 @@ class KebabCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toCamelCase', array(
             'some-kebab' => 'someKebab',
             'are-you-sure-i-mean-look-at-this' => 'areYouSureIMeanLookAtThis',
-            'i-got-0-problems' => 'iGot0Problems'
+            'i-got-0-problems' => 'iGot0Problems',
+            'dont-l👀k-at-me-like-that' => 'dontL👀kAtMeLikeThat',
+            'my-🍕-is-good' => 'my🍕IsGood',
+            "Friday-🍺s-forever" => 'friday🍺sForever'
         ));
     }
 
@@ -46,7 +55,10 @@ class KebabCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toPascalCase', array(
             'i-will-be-pascal-so-what' => 'IWillBePascalSoWhat',
             'you-know-youre-right' => 'YouKnowYoureRight',
-            '77-try-me-77' => '77TryMe77'
+            '77-try-me-77' => '77TryMe77',
+            'dont-l👀k-at-me-like-that' => 'DontL👀kAtMeLikeThat',
+            'my-🍕-is-good' => 'My🍕IsGood',
+            "friday-🍺s-forever" => 'Friday🍺sForever'
         ));
     }
 
@@ -55,7 +67,10 @@ class KebabCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toTrainCase', array(
             'da-kebab-stuff' => 'Da-Kebab-Stuff',
             'let-me-try-this-one' => 'Let-Me-Try-This-One',
-            'youre-my-number-1' => 'Youre-My-Number-1'
+            'youre-my-number-1' => 'Youre-My-Number-1',
+            'dont-l👀k-at-me-like-that' => 'Dont-L👀k-At-Me-Like-That',
+            'my-🍕-is-good' => 'My-🍕-Is-Good',
+            "friday-🍺s-forever" => 'Friday-🍺s-Forever'
         ));
     }
 
@@ -64,7 +79,10 @@ class KebabCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toSnakeCase', array(
             'mhh-yes' => 'mhh_yes',
             'another-one-should-be-added' => 'another_one_should_be_added',
-            'maybe_we-mix-this_up-a-little_bit' => 'maybe_we_mix_this_up_a_little_bit'
+            'maybe_we-mix-this_up-a-little_bit' => 'maybe_we_mix_this_up_a_little_bit',
+            'dont-l👀k-at-me-like-that' => 'dont_l👀k_at_me_like_that',
+            'my-🍕-is-good' => 'my_🍕_is_good',
+            "friday-🍺s-forever" => 'friday_🍺s_forever'
         ));
     }
 
@@ -72,6 +90,9 @@ class KebabCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toScreamingSnakeCase', array(
             'wow-this-is-cool' => 'WOW_THIS_IS_COOL',
             'do-you-hear-me?' => 'DO_YOU_HEAR_ME?',
+            'dont-l👀k-at-me-like-that' => 'DONT_L👀K_AT_ME_LIKE_THAT',
+            'my-🍕-is-good' => 'MY_🍕_IS_GOOD',
+            "friday-🍺s-forever" => 'FRIDAY_🍺S_FOREVER'
         ));
     }
 }

--- a/tests/Unit/CaseHelper/PascalCaseInputTest.php
+++ b/tests/Unit/CaseHelper/PascalCaseInputTest.php
@@ -21,7 +21,10 @@ class PascalCaseInputTest extends TestCase {
             'PascalCasedWord' => 'PascalCasedWord',
             'AnotherOne' => 'AnotherOne',
             'IThinkSo' => 'IThinkSo',
-            '12Test12' => '12Test12'
+            '12Test12' => '12Test12',
+            'DontL👀kAtMeLikeThat' => 'DontL👀kAtMeLikeThat',
+            'My🍕IsGood' => 'My🍕IsGood',
+            "Friday🍺sForever" => 'Friday🍺sForever'
         ));
     }
 
@@ -31,7 +34,10 @@ class PascalCaseInputTest extends TestCase {
             'IAmSoPascalCased' => 'i am so pascal cased',
             'LookAtMe' => 'look at me',
             'EverythingIsAlright' => 'everything is alright',
-            '1CheckThisOut2' => '1 check this out 2'
+            '1CheckThisOut2' => '1 check this out 2',
+            'DontL👀kAtMeLikeThat' => 'dont l👀k at me like that',
+            'My🍕IsGood' => 'my🍕 is good',
+            "Friday🍺sForever" => 'friday🍺s forever'
         ));
     }
 
@@ -40,7 +46,10 @@ class PascalCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toCamelCase', array(
             'MyStuffIsGood' => 'myStuffIsGood',
             'ILikeThisALot' => 'iLikeThisALot',
-            '123Meow456' => '123Meow456'
+            '123Meow456' => '123Meow456',
+            'DontL👀kAtMeLikeThat' => 'dontL👀kAtMeLikeThat',
+            'My🍕IsGood' => 'my🍕IsGood',
+            "Friday🍺sForever" => 'friday🍺sForever'
         ));
     }
 
@@ -49,7 +58,10 @@ class PascalCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toKebabCase', array(
             'MyPascalInput' => 'my-pascal-input',
             'SomethingOtherAlright' => 'something-other-alright',
-            'yup123' => 'yup-1-2-3'
+            'yup123' => 'yup-1-2-3',
+            'DontL👀kAtMeLikeThat' => 'dont-l👀k-at-me-like-that',
+            'My🍕IsGood' => 'my🍕-is-good',
+            "Friday🍺sForever" => 'friday🍺s-forever'
         ));
     }
 
@@ -58,7 +70,10 @@ class PascalCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toTrainCase', array(
             'YopOkay' => 'Yop-Okay',
             'LetsTryThisOne' => 'Lets-Try-This-One',
-            '234Okay' => '2-3-4-Okay'
+            '234Okay' => '2-3-4-Okay',
+            'DontL👀kAtMeLikeThat' => 'Dont-L👀k-At-Me-Like-That',
+            'My🍕IsGood' => 'My🍕-Is-Good',
+            "Friday🍺sForever" => 'Friday🍺s-Forever'
         ));
     }
 
@@ -66,7 +81,10 @@ class PascalCaseInputTest extends TestCase {
 
         $this->assertCaseHelperConvertsCasesCorrectly('toSnakeCase', array(
             'ASneakySnake' => 'A_Sneaky_Snake',
-            'WowThatsAwesome' => 'Wow_Thats_Awesome'
+            'WowThatsAwesome' => 'Wow_Thats_Awesome',
+            'DontL👀kAtMeLikeThat' => 'Dont_L👀k_At_Me_Like_That',
+            'My🍕IsGood' => 'My🍕_Is_Good',
+            "Friday🍺sForever" => 'Friday🍺s_Forever'
         ));
     }
 
@@ -74,7 +92,10 @@ class PascalCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toScreamingSnakeCase', array(
             'SupernaturalAndParanormal' => 'SUPERNATURAL_AND_PARANORMAL',
             'TestAllTheThings' => 'TEST_ALL_THE_THINGS',
-            '4TestWithNumbers3' => '4_TEST_WITH_NUMBERS_3'
+            '4TestWithNumbers3' => '4_TEST_WITH_NUMBERS_3',
+            'DontL👀kAtMeLikeThat' => 'DONT_L👀K_AT_ME_LIKE_THAT',
+            'My🍕IsGood' => 'MY🍕_IS_GOOD',
+            "Friday🍺sForever" => 'FRIDAY🍺S_FOREVER'
         ));
     }
 }

--- a/tests/Unit/CaseHelper/ScreamingSnakeCaseInputTest.php
+++ b/tests/Unit/CaseHelper/ScreamingSnakeCaseInputTest.php
@@ -19,7 +19,10 @@ class ScreamingSnakeCaseInputTest extends TestCase {
 
         $this->assertCaseHelperConvertsCasesCorrectly('toScreamingSnakeCase', array(
             'LEAVE_ME_ALONE' => 'LEAVE_ME_ALONE',
-            '3_NUMBERS_AND_STUFF_4' => '3_NUMBERS_AND_STUFF_4'
+            '3_NUMBERS_AND_STUFF_4' => '3_NUMBERS_AND_STUFF_4',
+            'DONT_L👀K_AT_ME_LIKE_THAT' => 'DONT_L👀K_AT_ME_LIKE_THAT',
+            'MY_🍕_IS_GOOD' => 'MY_🍕_IS_GOOD',
+            "FRIDAY_🍺S_FOREVER" => 'FRIDAY_🍺S_FOREVER'
         ));
     }
 
@@ -28,7 +31,10 @@ class ScreamingSnakeCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toSnakeCase', array(
             'OKAY_THEN' => 'okay_then',
             '3_TIMES_4_EQUALS_12' => '3_times_4_equals_12',
-            '2_COOL_4_YOU' => '2_cool_4_you'
+            '2_COOL_4_YOU' => '2_cool_4_you',
+            'DONT_L👀K_AT_ME_LIKE_THAT' => 'dont_l👀k_at_me_like_that',
+            'MY_🍕_IS_GOOD' => 'my_🍕_is_good',
+            "FRIDAY_🍺S_FOREVER" => 'friday_🍺s_forever'
         ));
     }
 
@@ -37,7 +43,10 @@ class ScreamingSnakeCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toSpaceCase', array(
             'TRY_ME_WITH_SPACES' => 'try me with spaces',
             'I_AM_NUMBER_1' => 'i am number 1',
-            '2_NUMBERS_2' => '2 numbers 2'
+            '2_NUMBERS_2' => '2 numbers 2',
+            'DONT_L👀K_AT_ME_LIKE_THAT' => 'dont l👀k at me like that',
+            'MY_🍕_IS_GOOD' => 'my 🍕 is good',
+            "FRIDAY_🍺S_FOREVER" => 'friday 🍺s forever'
         ));
     }
 
@@ -46,7 +55,10 @@ class ScreamingSnakeCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toTrainCase', array(
             'MAKE_ME_TRAIN_CASE' => 'Make-Me-Train-Case',
             '23_SOME_NUMBERS_12' => '23-Some-Numbers-12',
-            '4_REAL' => '4-Real'
+            '4_REAL' => '4-Real',
+            'DONT_L👀K_AT_ME_LIKE_THAT' => 'Dont-L👀k-At-Me-Like-That',
+            'MY_🍕_IS_GOOD' => 'My-🍕-Is-Good',
+            "FRIDAY_🍺S_FOREVER" => "Friday-🍺s-Forever"
         ));
     }
 
@@ -55,7 +67,10 @@ class ScreamingSnakeCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toPascalCase', array(
             'YO_OKAY_NOW' => 'YoOkayNow',
             '7_LUCKY_7' => '7Lucky7',
-            '4_ALL_PEOPLE' => '4AllPeople'
+            '4_ALL_PEOPLE' => '4AllPeople',
+            'DONT_L👀K_AT_ME_LIKE_THAT' => 'DontL👀kAtMeLikeThat',
+            'MY_🍕_IS_GOOD' => 'My🍕IsGood',
+            "FRIDAY_🍺S_FOREVER" => "Friday🍺sForever"
         ));
     }
 
@@ -64,7 +79,10 @@ class ScreamingSnakeCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toCamelCase', array(
             'CONVERT_ME_NOW' => 'convertMeNow',
             '3_YUP_YAP_4' => '3YupYap4',
-            '24_HOURS' => '24Hours'
+            '24_HOURS' => '24Hours',
+            'DONT_L👀K_AT_ME_LIKE_THAT' => 'dontL👀kAtMeLikeThat',
+            'MY_🍕_IS_GOOD' => 'my🍕IsGood',
+            "FRIDAY_🍺S_FOREVER" => "friday🍺sForever"
         ));
     }
 
@@ -73,7 +91,10 @@ class ScreamingSnakeCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toKebabCase', array(
             'MY_CAPSLOCK_DOESNT_WORK_ANYMORE' => 'my-capslock-doesnt-work-anymore',
             '4_REAL_MAN' => '4-real-man',
-            '1_NUMBERS_3' => '1-numbers-3'
+            '1_NUMBERS_3' => '1-numbers-3',
+            'DONT_L👀K_AT_ME_LIKE_THAT' => 'dont-l👀k-at-me-like-that',
+            'MY_🍕_IS_GOOD' => 'my-🍕-is-good',
+            "FRIDAY_🍺S_FOREVER" => "friday-🍺s-forever"
         ));
     }
 }

--- a/tests/Unit/CaseHelper/SnakeCaseInputTest.php
+++ b/tests/Unit/CaseHelper/SnakeCaseInputTest.php
@@ -19,7 +19,10 @@ class SnakeCaseInputTest extends TestCase {
 
         $this->assertCaseHelperConvertsCasesCorrectly('toSnakeCase', array(
             'my_snake_str' => 'my_snake_str',
-            '3_times_yolo' => '3_times_yolo'
+            '3_times_yolo' => '3_times_yolo',
+            'dont_l👀k_at_me_like_that' => 'dont_l👀k_at_me_like_that',
+            'my_🍕_is_good' => 'my_🍕_is_good',
+            "friday_🍺s_forever" => 'friday_🍺s_forever'
         ));
     }
 
@@ -27,7 +30,10 @@ class SnakeCaseInputTest extends TestCase {
 
         $this->assertCaseHelperConvertsCasesCorrectly('toScreamingSnakeCase', array(
             'lets_get_loud' => 'LETS_GET_LOUD',
-            '1337_is_short_for_31337' => '1337_IS_SHORT_FOR_31337'
+            '1337_is_short_for_31337' => '1337_IS_SHORT_FOR_31337',
+            'dont_l👀k_at_me_like_that' => 'DONT_L👀K_AT_ME_LIKE_THAT',
+            'my_🍕_is_good' => 'MY_🍕_IS_GOOD',
+            "friday_🍺s_forever" => 'FRIDAY_🍺S_FOREVER'
         ));
     }
 
@@ -36,7 +42,10 @@ class SnakeCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toSpaceCase', array(
             'make_me_spaced' => 'make me spaced',
             '1_what_2' => '1 what 2',
-            '4_you' => '4 you'
+            '4_you' => '4 you',
+            'dont_l👀k_at_me_like_that' => 'dont l👀k at me like that',
+            'my_🍕_is_good' => 'my 🍕 is good',
+            "friday_🍺s_forever" => 'friday 🍺s forever'
         ));
     }
 
@@ -45,7 +54,10 @@ class SnakeCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toTrainCase', array(
             'i_want_to_be_train_case' => 'I-Want-To-Be-Train-Case',
             'me_too' => 'Me-Too',
-            '4_you_2' => '4-You-2'
+            '4_you_2' => '4-You-2',
+            'dont_l👀k_at_me_like_that' => 'Dont-L👀k-At-Me-Like-That',
+            'my_🍕_is_good' => 'My-🍕-Is-Good',
+            "friday_🍺s_forever" => 'Friday-🍺s-Forever'
         ));
     }
 
@@ -53,7 +65,10 @@ class SnakeCaseInputTest extends TestCase {
 
         $this->assertCaseHelperConvertsCasesCorrectly('toPascalCase', array(
             'some_snake_stuff' => 'SomeSnakeStuff',
-            '3_whatever_it_may_be_4' => '3WhateverItMayBe4'
+            '3_whatever_it_may_be_4' => '3WhateverItMayBe4',
+            'dont_l👀k_at_me_like_that' => 'DontL👀kAtMeLikeThat',
+            'my_🍕_is_good' => 'My🍕IsGood',
+            "friday_🍺s_forever" => 'Friday🍺sForever'
         ));
     }
 
@@ -62,7 +77,10 @@ class SnakeCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toCamelCase', array(
             'check_it_out' => 'checkItOut',
             '3_some_numbers_12' => '3SomeNumbers12',
-            'good_4_you' => 'good4You'
+            'good_4_you' => 'good4You',
+            'dont_l👀k_at_me_like_that' => 'dontL👀kAtMeLikeThat',
+            'my_🍕_is_good' => 'my🍕IsGood',
+            "Friday_🍺s_forever" => 'friday🍺sForever'
         ));
     }
 
@@ -71,7 +89,10 @@ class SnakeCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toKebabCase', array(
             'make_me_kebab' => 'make-me-kebab',
             '12_is_equal_to_12' => '12-is-equal-to-12',
-            'ya_2' => 'ya-2'
+            'ya_2' => 'ya-2',
+            'dont_l👀k_at_me_like_that' => 'dont-l👀k-at-me-like-that',
+            'my_🍕_is_good' => 'my-🍕-is-good',
+            "friday_🍺s_forever" => 'friday-🍺s-forever'
         ));
     }
 }

--- a/tests/Unit/CaseHelper/SpaceCaseInputTest.php
+++ b/tests/Unit/CaseHelper/SpaceCaseInputTest.php
@@ -19,7 +19,10 @@ class SpaceCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toSpaceCase', array(
             'My space case...' => 'My space case...',
             'You should not change me, okay?!' => 'You should not change me, okay?!',
-            '123...Test...321' => '123...Test...321'
+            '123...Test...321' => '123...Test...321',
+            'Dont l👀k at me like that' => 'Dont l👀k at me like that',
+            'My 🍕 is good' => 'My 🍕 is good',
+            "Friday 🍺s forever" => 'Friday 🍺s forever'
         ));
     }
 
@@ -27,7 +30,11 @@ class SpaceCaseInputTest extends TestCase {
 
         $this->assertCaseHelperConvertsCasesCorrectly('toCamelCase', array(
             '...convert me to camel, please! ' => 'convertMeToCamelPlease',
-            'yeah; me    too :> #yolo' => 'yeahMeTooYolo'
+            'My space case...' => 'mySpaceCase',
+            'yeah; me    too :> #yolo' => 'yeahMeTooYolo',
+            'Dont l👀k at me like that' => 'dontLkAtMeLikeThat',
+            'My 🍕 is good' => 'myIsGood',
+            "Friday 🍺s forever" => 'fridaySForever'
         ));
     }
 
@@ -35,7 +42,10 @@ class SpaceCaseInputTest extends TestCase {
 
         $this->assertCaseHelperConvertsCasesCorrectly('toPascalCase', array(
             '  some sentence right here... let\'s see...' => 'SomeSentenceRightHereLetsSee',
-            ' another one 23 ' => 'AnotherOne23'
+            ' another one 23 ' => 'AnotherOne23',
+            'dont l👀k at me like that' => 'DontLkAtMeLikeThat',
+            'my 🍕 is gOod' => 'MyIsGOod',
+            "friday 🍺s foRever" => 'FridaySFoRever'
         ));
     }
 
@@ -44,7 +54,10 @@ class SpaceCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toKebabCase', array(
             ' I wanna be kebab... really# ' => 'i-wanna-be-kebab-really',
             'yes dunno what 2 write' => 'yes-dunno-what-2-write',
-            '3 is more than 2' => '3-is-more-than-2'
+            '3 is more than 2' => '3-is-more-than-2',
+            'Dont l👀k at me like that' => 'dont-lk-at-me-like-that',
+            'My 🍕 is good' => 'my-is-good',
+            "Friday 🍺s forever" => 'friday-s-forever'
         ));
     }
 
@@ -53,7 +66,10 @@ class SpaceCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toTrainCase', array(
             ' I see #trains ! ' => 'I-See-Trains',
             'let\'s see...' => 'Lets-See',
-            '4 equals 2 times 2' => '4-Equals-2-Times-2'
+            '4 equals 2 times 2' => '4-Equals-2-Times-2',
+            'Dont l👀k at me like that' => 'Dont-Lk-At-Me-Like-That',
+            'My 🍕 is good' => 'My-Is-Good',
+            "Friday 🍺s forever" => 'Friday-S-Forever'
         ));
     }
 
@@ -70,7 +86,10 @@ class SpaceCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toScreamingSnakeCase', array(
             ' do the Cpt. Capslock for me' => 'DO_THE_CPT_CAPSLOCK_FOR_ME',
             ' i agree ! ' => 'I_AGREE',
-            ' 123# Stuff with numbers 456#!' => '123_STUFF_WITH_NUMBERS_456'
+            ' 123# Stuff with numbers 456#!' => '123_STUFF_WITH_NUMBERS_456',
+            'Dont l👀k at me like that' => 'DONT_LK_AT_ME_LIKE_THAT',
+            'My 🍕 is good' => 'MY_IS_GOOD',
+            "Friday 🍺s forever" => 'FRIDAY_S_FOREVER'
         ));
     }
 }

--- a/tests/Unit/CaseHelper/TrainCaseInputTest.php
+++ b/tests/Unit/CaseHelper/TrainCaseInputTest.php
@@ -19,7 +19,10 @@ class TrainCaseInputTest extends TestCase {
 
         $this->assertCaseHelperConvertsCasesCorrectly('toTrainCase', array(
             'My-Train-Case-Str' => 'My-Train-Case-Str',
-            'Yup' => 'Yup'
+            'Yup' => 'Yup',
+            'Dont-L👀k-At-Me-Like-That' => 'Dont-L👀k-At-Me-Like-That',
+            'My-🍕-Is-Good' => 'My-🍕-Is-Good',
+            "Friday-🍺s-Forever" => 'Friday-🍺s-Forever'
         ));
     }
 
@@ -28,7 +31,10 @@ class TrainCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toSpaceCase', array(
             'I-Am-Train-Cased' => 'i am train cased',
             '2-To-Go-4' => '2 to go 4',
-            'Ok' => 'ok'
+            'Ok' => 'ok',
+            'Dont-L👀k-At-Me-Like-That' => 'dont l👀k at me like that',
+            'My-🍕-Is-Good' => 'my 🍕 is good',
+            "Friday-🍺s-Forever" => 'friday 🍺s forever'
         ));
     }
 
@@ -38,7 +44,10 @@ class TrainCaseInputTest extends TestCase {
             'Some-Train-Case-Stuff' => 'SomeTrainCaseStuff',
             'I-Dont-Know-What-To-Write' => 'IDontKnowWhatToWrite',
             '9-Whatever-9' => '9Whatever9',
-            'N8' => 'N8'
+            'N8' => 'N8',
+            'Dont-L👀k-At-Me-Like-That' => 'DontL👀kAtMeLikeThat',
+            'My-🍕-Is-Good' => 'My🍕IsGood',
+            "Friday-🍺s-Forever" => 'Friday🍺sForever'
         ));
     }
 
@@ -48,7 +57,10 @@ class TrainCaseInputTest extends TestCase {
             'Test-Me-Now-Do-It' => 'testMeNowDoIt',
             'Aww-Alright-Then' => 'awwAlrightThen',
             '1338-Is-One-Step-Ahead' => '1338IsOneStepAhead',
-            'Ending-With-Number-3' => 'endingWithNumber3'
+            'Ending-With-Number-3' => 'endingWithNumber3',
+            'Dont-L👀k-At-Me-Like-That' => 'dontL👀kAtMeLikeThat',
+            'My-🍕-Is-Good' => 'my🍕IsGood',
+            "Friday-🍺s-Forever" => 'friday🍺sForever'
         ));
     }
 
@@ -57,7 +69,10 @@ class TrainCaseInputTest extends TestCase {
         $this->assertCaseHelperConvertsCasesCorrectly('toKebabCase', array(
             'I-Like-Icecream' => 'i-like-icecream',
             'This-Is-Great' => 'this-is-great',
-            '4-Eva' => '4-eva'
+            '4-Eva' => '4-eva',
+            'Dont-L👀k-At-Me-Like-That' => 'dont-l👀k-at-me-like-that',
+            'My-🍕-Is-Good' => 'my-🍕-is-good',
+            "Friday-🍺s-Forever" => 'friday-🍺s-forever'
         ));
     }
 
@@ -67,7 +82,10 @@ class TrainCaseInputTest extends TestCase {
             'Yup-Yup-Ya' => 'yup_yup_ya',
             'I-Like' => 'i_like',
             '2-Cool-4-You' => '2_cool_4_you',
-            'Stuff-Times-3' => 'stuff_times_3'
+            'Stuff-Times-3' => 'stuff_times_3',
+            'Dont-L👀k-At-Me-Like-That' => 'dont_l👀k_at_me_like_that',
+            'My-🍕-Is-Good' => 'my_🍕_is_good',
+            "Friday-🍺s-Forever" => 'friday_🍺s_forever'
         ));
     }
 
@@ -77,7 +95,10 @@ class TrainCaseInputTest extends TestCase {
             'Yup' => 'YUP',
             'I-Like-Testing' => 'I_LIKE_TESTING',
             'Something-1337-Pls' => 'SOMETHING_1337_PLS',
-            '1-Yes-1' => '1_YES_1'
+            '1-Yes-1' => '1_YES_1',
+            'Dont-L👀k-At-Me-Like-That' => 'DONT_L👀K_AT_ME_LIKE_THAT',
+            'My-🍕-Is-Good' => 'MY_🍕_IS_GOOD',
+            "Friday-🍺s-Forever" => 'FRIDAY_🍺S_FOREVER'
         ));
     }
 }


### PR DESCRIPTION
This PR allows to convert my-🍕-is-good to MY_🍕_IS_GOOD 😄 

As GitHub and all modern websites, I want to support all emojis and other stupid 웃 and unexpected 卐 chars on my applications.

Some cases, like camel, don't catch caps on emoji though (sounds fair), so camelCase my🍕IsGood 
will be converted to space case my🍕 is good. Bug or feature? 🐞 

By the way, I am wondering why the SpaceCaseHelper removes all non alphanumeric characters (there's that `clearString` method). They remove my pizzas and my beers, not a tough idea during the week-end you know! - Did not fix but I don't understand so I will remove this behavior in another PR to open the discussion.

Other question: it looks like most of the time, camelCase means "lower camelcase" and PascalCase means "upper camelcase", but this is not the case in the SpaceCaseHandler. Here, I fixed it for better consistency.

Note that for people who don't support mbstring, I added the nice symfony polyfill-mbstring as a composer dependency. Bisous nicolas grekas 😘

With love ❤